### PR TITLE
Add uuid support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "limine"
 version = "0.1.6"
 dependencies = [
  "limine-proc",
+ "uuid",
 ]
 
 [[package]]
@@ -53,3 +54,9 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["no-std"]
 
 [features]
 requests-section = ["limine-proc"]
+into-uuid = ["uuid"]
 default = []
 
 [dependencies]
 limine-proc = { optional = true, version = "0.1.0" }
+uuid = { optional = true, version = "1.1.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,21 @@ pub struct LimineUuid {
     pub d: [u8; 8],
 }
 
+#[cfg(feature = "into-uuid")]
+impl From<LimineUuid> for uuid::Uuid {
+    fn from(lim: LimineUuid) -> Self {
+        Self::from_fields(lim.a, lim.b, lim.c, &lim.d)
+    }
+}
+
+#[cfg(feature = "into-uuid")]
+impl From<uuid::Uuid> for LimineUuid {
+    fn from(uuid: uuid::Uuid) -> Self {
+        let (a, b, c, d) = uuid.as_fields();
+        Self { a, b, c, d: d.clone() }
+    }
+}
+
 #[derive(Debug)]
 pub struct LimineFile {
     /// Revision of this structure.


### PR DESCRIPTION
Same as I did on the stivale repo; this adds integration with the `uuid` crate via the `into-uuid` feature. I'm open to other ideas for the name.