### PR TITLE
Update Rust feature flags.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! * [Limine Boot Protocol Specification](https://github.com/limine-bootloader/limine/blob/trunk/PROTOCOL.md)
 
 #![no_std]
+#![feature(const_fn_fn_ptr_basics)]
 #![feature(const_nonnull_new)]
 
 #[cfg(feature = "requests-section")]


### PR DESCRIPTION
I get this when trying to compile.

```
error[E0658]:` function pointers cannot appear in constant functions
  --> D:\Software\Toolchains\Cargo\registry\src\github.com-1ecc6299db9ec823\limine-0.1.8\src\lib.rs:74:22
   |
74 |     pub const fn new(entry_point: fn() -> !) -> Self {
   |                      ^^^^^^^^^^^
   |
   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
   = help: add `#![feature(const_fn_fn_ptr_basics)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
```