### PR TITLE
Fixed terminal column count returning row count and vice versa

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,10 +309,10 @@ make_struct!(
 #[repr(C)]
 #[derive(Debug)]
 pub struct LimineTerminal {
-    /// Number of rows provided by the terminal.
-    pub rows: u64,
     /// Number of columns provided by the terminal.
     pub cols: u64,
+    /// Number of rows provided by the terminal.
+    pub rows: u64,
     /// The framebuffer associated with this terminal.
     pub framebuffer: LiminePtr<LimineFramebuffer>,
 }


### PR DESCRIPTION
This Pull Request fixes an issue where the terminal column count would return the terminal row count and vice versa.