### PR TITLE
Derive or implement `Debug` where possible

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -12,7 +12,7 @@ use core::net::{Ipv4Addr, SocketAddrV4};
 /// A UUID. With the `uuid` feature, this can be converted directly to
 /// [`uuid::Uuid`] via [`Into`], and the reverse via [`From`].
 #[repr(C)]
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct Uuid {
     /// The first 32 bits of the UUID.
     pub a: u32,
@@ -47,7 +47,7 @@ impl From<Uuid> for uuid::Uuid {
 }
 
 /// A media type for a file.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[repr(transparent)]
 pub struct MediaType(u32);
 impl MediaType {
@@ -63,6 +63,7 @@ impl MediaType {
 /// [`KernelFileRequest`](crate::request::KernelFileRequest) and
 /// [`ModuleRequest`](crate::request::ModuleRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct File {
     revision: u64,
     addr: *mut c_void,

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,8 +1,9 @@
 //! Auxiliary types for the [framebuffer request](crate::request::FramebufferRequest)
 
 use core::ffi::c_void;
+use core::fmt;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub(crate) struct RawFramebufferV0 {
     addr: *mut c_void,
@@ -22,7 +23,7 @@ pub(crate) struct RawFramebufferV0 {
     edid: *mut u8,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub(crate) struct RawFramebufferV1 {
     _v0: RawFramebufferV0,
@@ -36,10 +37,19 @@ pub(crate) union RawFramebuffer {
     v1: RawFramebufferV1,
 }
 
+impl fmt::Debug for RawFramebuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: RawFramebufferV0 is a subset of RawFramebufferV1,
+        // and their placement in memory is the same, so v0 is always
+        // safe to access.
+        unsafe { self.v0.fmt(f) }
+    }
+}
+
 /// A memory model used by a framebuffer. Currently only
 /// [`MemoryModel::RGB`](Self::RGB) is defined.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct MemoryModel(u8);
 impl MemoryModel {
     /// This is an RGB framebuffer.
@@ -48,6 +58,7 @@ impl MemoryModel {
 
 /// A mode supported by the current framebuffer.
 #[repr(C)]
+#[derive(Debug)]
 pub struct VideoMode {
     /// The pitch (distance between rows, in bytes). This is not always the same
     /// as `(width * bpp) / 8`, as padding bytes may be added to achieve a
@@ -88,6 +99,7 @@ pub struct VideoMode {
 /// Two revisions currently exist of the framebuffer type. However, the type
 /// itself has no revision field. In order to keep this type safe, we wrap the
 /// pointer with its associated revision taken from the response.
+#[derive(Debug)]
 pub struct Framebuffer<'a> {
     revision: u64,
     inner: &'a RawFramebuffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![deny(missing_docs)]
+#![warn(missing_debug_implementations)]
 
 //! Rust Bindings for the limine boot protocol.
 //!
@@ -69,6 +70,7 @@ pub mod smp;
 /// bootloader will assume revision 0.
 ///
 /// The latest revision is 1.
+#[derive(Debug)]
 pub struct BaseRevision {
     _id: [u64; 2],
     revision: UnsafeCell<u64>,

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -2,7 +2,7 @@
 
 /// A type of entry within the memory map.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct EntryType(u64);
 impl EntryType {
     /// The memory region is freely usable.
@@ -34,6 +34,7 @@ impl From<u64> for EntryType {
 
 /// A memory map entry.
 #[repr(C)]
+#[derive(Debug)]
 pub struct Entry {
     /// The base of the memory region, in *physical space*.
     pub base: u64,

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Flags for internal modules
-    #[derive(PartialEq, Eq, Clone, Copy)]
+    #[derive(PartialEq, Eq, Clone, Copy, Debug)]
     pub struct ModuleFlags: u64 {
         /// The module is required. If it is not found, the bootloader will
         /// refuse to boot.
@@ -31,6 +31,7 @@ macro_rules! cstr {
 /// An internal module that the kernel requests from the bootloader. Only
 /// available with request revision 1 and greater.
 #[repr(C)]
+#[derive(Debug)]
 pub struct InternalModule {
     path: *const c_char,
     cmdline: *const c_char,

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -5,13 +5,13 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Paging mode flags. None are currently specified.
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Clone, Copy, Debug)]
     pub struct Flags: u64 {}
 }
 
 /// A paging mode.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct Mode(u64);
 impl From<u64> for Mode {
     fn from(value: u64) -> Self {

--- a/src/request.rs
+++ b/src/request.rs
@@ -75,6 +75,7 @@ macro_rules! magic {
     };
 }
 
+#[derive(Debug)]
 struct Response<T> {
     inner: UnsafeCell<Option<NonNull<T>>>,
 }
@@ -112,6 +113,7 @@ impl<T> Response<T> {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct BootloaderInfoRequest {
     id: [u64; 4],
     revision: u64,
@@ -142,6 +144,7 @@ impl BootloaderInfoRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct StackSizeRequest {
     id: [u64; 4],
     revision: u64,
@@ -188,6 +191,7 @@ impl StackSizeRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct HhdmRequest {
     id: [u64; 4],
     revision: u64,
@@ -217,6 +221,7 @@ impl HhdmRequest {
 /// FRAMEBUFFER_REQUEST.get_response() // ...
 /// # }
 #[repr(C)]
+#[derive(Debug)]
 pub struct FramebufferRequest {
     id: [u64; 4],
     revision: u64,
@@ -250,6 +255,7 @@ impl FramebufferRequest {
 /// PAGING_MODE_REQUEST.get_response() // ...
 /// # }
 #[repr(C)]
+#[derive(Debug)]
 pub struct PagingModeRequest {
     id: [u64; 4],
     revision: u64,
@@ -319,6 +325,7 @@ impl PagingModeRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 #[deprecated(note = "use `PagingModeRequest` instead")]
 pub struct FiveLevelPagingRequest {
     id: [u64; 4],
@@ -352,6 +359,7 @@ impl FiveLevelPagingRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct SmpRequest {
     id: [u64; 4],
     revision: u64,
@@ -405,6 +413,7 @@ impl SmpRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct MemoryMapRequest {
     id: [u64; 4],
     revision: u64,
@@ -422,6 +431,7 @@ impl MemoryMapRequest {
 /// Requests limine to use a specific function as the kernel entry point,
 /// instead of the one specified in the ELF.
 #[repr(C)]
+#[derive(Debug)]
 pub struct EntryPointRequest {
     id: [u64; 4],
     revision: u64,
@@ -476,6 +486,7 @@ impl EntryPointRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct KernelFileRequest {
     id: [u64; 4],
     revision: u64,
@@ -518,6 +529,7 @@ impl KernelFileRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct ModuleRequest {
     id: [u64; 4],
     revision: u64,
@@ -591,6 +603,7 @@ impl ModuleRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct RsdpRequest {
     id: [u64; 4],
     revision: u64,
@@ -621,6 +634,7 @@ impl RsdpRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct SmbiosRequest {
     id: [u64; 4],
     revision: u64,
@@ -651,6 +665,7 @@ impl SmbiosRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct EfiSystemTableRequest {
     id: [u64; 4],
     revision: u64,
@@ -681,6 +696,7 @@ impl EfiSystemTableRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct EfiMemoryMapRequest {
     id: [u64; 4],
     revision: u64,
@@ -711,6 +727,7 @@ impl EfiMemoryMapRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct BootTimeRequest {
     id: [u64; 4],
     revision: u64,
@@ -741,6 +758,7 @@ impl BootTimeRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct KernelAddressRequest {
     id: [u64; 4],
     revision: u64,
@@ -771,6 +789,7 @@ impl KernelAddressRequest {
 /// # }
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct DeviceTreeBlobRequest {
     id: [u64; 4],
     revision: u64,

--- a/src/response.rs
+++ b/src/response.rs
@@ -26,6 +26,7 @@ macro_rules! impl_base_fns {
 /// A response to a [bootloader info
 /// request](crate::request::BootloaderInfoRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct BootloaderInfoResponse {
     revision: u64,
     name: *const c_char,
@@ -51,6 +52,7 @@ impl BootloaderInfoResponse {
 /// response has no fields. If it is provided, the bootloader complied with the
 /// request.
 #[repr(C)]
+#[derive(Debug)]
 pub struct StackSizeResponse {
     revision: u64,
 }
@@ -61,6 +63,7 @@ impl StackSizeResponse {
 /// A response to a [higher-half direct map
 /// request](crate::request::HhdmRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct HhdmResponse {
     revision: u64,
     offset: u64,
@@ -98,6 +101,7 @@ impl HhdmResponse {
 
 /// A response to a [framebuffer request](crate::request::FramebufferRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct FramebufferResponse {
     revision: u64,
     framebuffer_ct: u64,
@@ -119,6 +123,7 @@ impl FramebufferResponse {
 
 /// A response to a [paging mode request](crate::request::PagingModeRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct PagingModeResponse {
     revision: u64,
     mode: Mode,
@@ -147,6 +152,7 @@ impl PagingModeResponse {
 /// request](crate::request::FiveLevelPagingRequest). This response has no
 /// fields. If it is provided, five-level paging is supported and enabled.
 #[repr(C)]
+#[derive(Debug)]
 pub struct FiveLevelPagingResponse {
     revision: u64,
 }
@@ -157,6 +163,7 @@ impl FiveLevelPagingResponse {
 /// A response to a [smp request](crate::request::SmpRequest). This response
 /// contains information about the boot processor and all other processors.
 #[repr(C)]
+#[derive(Debug)]
 pub struct SmpResponse {
     revision: u64,
     flags: smp::ResponseFlags,
@@ -217,6 +224,7 @@ impl SmpResponse {
 
 /// A response to a [memory map request](crate::request::MemoryMapRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct MemoryMapResponse {
     revision: u64,
     entry_ct: u64,
@@ -244,6 +252,7 @@ impl MemoryMapResponse {
 
 /// A response to a [kernel file request](crate::request::KernelFileRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct EntryPointResponse {
     revision: u64,
 }
@@ -253,6 +262,7 @@ impl EntryPointResponse {
 
 /// A response to a [kernel file request](crate::request::KernelFileRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct KernelFileResponse {
     revision: u64,
     file: *const file::File,
@@ -270,6 +280,7 @@ impl KernelFileResponse {
 
 /// A response to a [module request](crate::request::ModuleRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct ModuleResponse {
     revision: u64,
     module_ct: u64,
@@ -289,6 +300,7 @@ impl ModuleResponse {
 
 /// A response to a [rsdp request](crate::request::RsdpRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct RsdpResponse {
     revision: u64,
     address: *const c_void,
@@ -306,6 +318,7 @@ impl RsdpResponse {
 
 /// A response to a [smbios request](crate::request::SmbiosRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct SmbiosResponse {
     revision: u64,
     entry_32: Option<NonNull<c_void>>,
@@ -328,6 +341,7 @@ impl SmbiosResponse {
 
 /// A response to a [system table request](crate::request::EfiSystemTableRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct EfiSystemTableResponse {
     revision: u64,
     address: *const c_void,
@@ -345,6 +359,7 @@ impl EfiSystemTableResponse {
 
 /// A response to a [memory map request](crate::request::EfiMemoryMapRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct EfiMemoryMapResponse {
     revision: u64,
     memmap: *const c_void,
@@ -378,6 +393,7 @@ impl EfiMemoryMapResponse {
 
 /// A response to a [boot time request](crate::request::BootTimeRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct BootTimeResponse {
     revision: u64,
     boot_time: i64,
@@ -402,6 +418,7 @@ impl BootTimeResponse {
 /// let phys_addr = virt_addr - virtual_base + physical_base;
 /// ````
 #[repr(C)]
+#[derive(Debug)]
 pub struct KernelAddressResponse {
     revision: u64,
     physical_base: u64,
@@ -422,6 +439,7 @@ impl KernelAddressResponse {
 
 /// A response to a [device tree blob request](crate::request::DeviceTreeBlobRequest).
 #[repr(C)]
+#[derive(Debug)]
 pub struct DeviceTreeBlobResponse {
     revision: u64,
     dtb_ptr: *const c_void,

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -6,6 +6,7 @@ use bitflags::bitflags;
 
 /// A function pointer that the core will jump to when it is written to.
 #[repr(transparent)]
+#[derive(Debug)]
 pub struct GotoAddress {
     inner: AtomicPtr<()>,
 }
@@ -22,6 +23,7 @@ impl GotoAddress {
 /// A CPU entry in the SMP request.
 #[cfg(target_arch = "x86_64")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
     pub id: u32,
@@ -39,6 +41,7 @@ pub struct Cpu {
 /// A CPU entry in the SMP request.
 #[cfg(target_arch = "aarch64")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
     pub id: u32,
@@ -58,6 +61,7 @@ pub struct Cpu {
 /// A CPU entry in the SMP request.
 #[cfg(target_arch = "riscv64")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
     pub id: u64,
@@ -74,7 +78,7 @@ pub struct Cpu {
 
 bitflags! {
     /// Flags for the [SMP request](crate::request::SmpRequest).
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Clone, Copy, Debug)]
     pub struct RequestFlags: u64 {
         /// Initialize the X2APIC.
         #[cfg(target_arch = "x86_64")]
@@ -85,7 +89,7 @@ bitflags! {
 #[cfg(target_arch = "x86_64")]
 bitflags! {
     /// Flags for the [SMP response](crate::response::SmpResponse).
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Clone, Copy, Debug)]
     pub struct ResponseFlags: u32 {
         /// The X2APIC was initialized.
         #[cfg(target_arch = "x86_64")]
@@ -96,6 +100,6 @@ bitflags! {
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 bitflags! {
     /// Flags for the [SMP response](crate::response::SmpResponse).
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Clone, Copy, Debug)]
     pub struct ResponseFlags: u64 {}
 }


### PR DESCRIPTION
Add a `Debug` trait derive or implementation for pub structs, and add a lint (`warn(missing_debug_implementations)`) to warn about their absence in the future.