### PR TITLE
BaseRevision should be repr(C)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub mod smp;
 /// bootloader will assume revision 0.
 ///
 /// The latest revision is 1.
+#[repr(C)]
 pub struct BaseRevision {
     _id: [u64; 2],
     revision: UnsafeCell<u64>,


### PR DESCRIPTION
Currently, the rust compiler is allowed to rearrange the fields of `BaseRevision`. If it does so, it would break compatibility with the limine protocol. This PR makes it `repr(C)` to prevent this.