### PR TITLE
Update limine protocol

### DIFF
--- a/src/firmware_type.rs
+++ b/src/firmware_type.rs
@@ -1,0 +1,20 @@
+//! Auxiliary types for the [firmware type request
+//! ](crate::request::FirmwareTypeRequest).
+
+/// A firmware type.
+#[repr(transparent)]
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct FirmwareType(u64);
+impl FirmwareType {
+    /// The firmware type is x86 BIOS.
+    pub const X86_BIOS: Self = Self(0);
+    /// The firmware type is 32-bit UEFI.
+    pub const UEFI_32: Self = Self(1);
+    /// The firmware type is 64-bit UEFI.
+    pub const UEFI_64: Self = Self(2);
+}
+impl From<u64> for FirmwareType {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! ```rust
 //! use limine::BaseRevision;
 //!
-//! // Require version 1 or higher
+//! // Require version 2 or higher
 //! pub static BASE_REVISION: BaseRevision = BaseRevision::new();
 //! ```
 //!
@@ -59,6 +59,7 @@
 use core::cell::UnsafeCell;
 
 pub mod file;
+pub mod firmware_type;
 pub mod framebuffer;
 pub mod memory_map;
 pub mod modules;
@@ -71,7 +72,7 @@ pub mod smp;
 /// kernel in order to require a higher revision. Without this tag, the
 /// bootloader will assume revision 0.
 ///
-/// The latest revision is 1.
+/// The latest revision is 2.
 #[repr(C)]
 pub struct BaseRevision {
     _id: [u64; 2],
@@ -80,7 +81,7 @@ pub struct BaseRevision {
 impl BaseRevision {
     /// Create a new base revision tag with the latest revision.
     pub const fn new() -> Self {
-        Self::with_revision(1)
+        Self::with_revision(2)
     }
 
     /// Create a new base revision tag with the given revision.

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,14 +1,6 @@
 //! Auxiliary types for the [paging mode
 //! request](crate::request::PagingModeRequest).
 
-use bitflags::bitflags;
-
-bitflags! {
-    /// Paging mode flags. None are currently specified.
-    #[derive(Default, Clone, Copy)]
-    pub struct Flags: u64 {}
-}
-
 /// A paging mode.
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -25,6 +17,13 @@ impl Mode {
     pub const FOUR_LEVEL: Self = Self(0);
     /// (x86_64 and aarch64) Five-level paging (i.e. 52-bit virtual addresses on x86_64).
     pub const FIVE_LEVEL: Self = Self(1);
+
+    /// The default paging mode.
+    pub const DEFAULT: Self = Self::FOUR_LEVEL;
+    /// The maximum supported paging mode.
+    pub const MAX: Self = Self::FIVE_LEVEL;
+    /// The minimum supported paging mode.
+    pub const MIN: Self = Self::FOUR_LEVEL;
 }
 
 #[cfg(target_arch = "riscv64")]
@@ -35,4 +34,24 @@ impl Mode {
     pub const SV48: Self = Self(1);
     /// (riscv64 only) SV57, i.e. 57-bit virtual addresses.
     pub const SV57: Self = Self(2);
+
+    /// The default paging mode.
+    pub const DEFAULT: Self = Self::SV48;
+    /// The maximum supported paging mode.
+    pub const MAX: Self = Self::SV57;
+    /// The minimum supported paging mode.
+    pub const MIN: Self = Self::SV39;
+}
+
+#[cfg(target_arch = "loongarch64")]
+impl Mode {
+    /// (loongarch64 only) Four-level paging.
+    pub const FOUR_LEVEL: Self = Self(0);
+
+    /// The default paging mode.
+    pub const DEFAULT: Self = Self::FOUR_LEVEL;
+    /// The maximum supported paging mode.
+    pub const MAX: Self = Self::FOUR_LEVEL;
+    /// The minimum supported paging mode.
+    pub const MIN: Self = Self::FOUR_LEVEL;
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,9 +8,10 @@ use core::{
 
 use crate::{
     file,
+    firmware_type::FirmwareType,
     framebuffer::{Framebuffer, RawFramebuffer},
     memory_map,
-    paging::{Flags, Mode},
+    paging::Mode,
     smp,
 };
 
@@ -44,6 +45,22 @@ impl BootloaderInfoResponse {
     /// Returns the version of the loading bootloader.
     pub fn version(&self) -> &str {
         unsafe { CStr::from_ptr(self.version) }.to_str().unwrap()
+    }
+}
+
+/// A response to a [firmware type request
+/// ](crate::request::FirmwareTypeRequest).
+#[repr(C)]
+pub struct FirmwareTypeResponse {
+    revision: u64,
+    firmware_type: FirmwareType,
+}
+impl FirmwareTypeResponse {
+    impl_base_fns!();
+
+    /// Returns the firmware type.
+    pub fn firmware_type(&self) -> FirmwareType {
+        self.firmware_type
     }
 }
 
@@ -122,7 +139,6 @@ impl FramebufferResponse {
 pub struct PagingModeResponse {
     revision: u64,
     mode: Mode,
-    flags: Flags,
 }
 impl PagingModeResponse {
     impl_base_fns!();
@@ -132,26 +148,6 @@ impl PagingModeResponse {
     pub fn mode(&self) -> Mode {
         self.mode
     }
-    /// Returns the flags that were enabled by the bootloader. See [`Flags`] for
-    /// more information.
-    pub fn flags(&self) -> Flags {
-        self.flags
-    }
-}
-
-/// **This request is deprecated and was removed from the reference
-/// implementation. Use [`PagingModeRequest`](crate::request::PagingModeRequest)
-/// instead.**
-///
-/// A response to a [five-level paging
-/// request](crate::request::FiveLevelPagingRequest). This response has no
-/// fields. If it is provided, five-level paging is supported and enabled.
-#[repr(C)]
-pub struct FiveLevelPagingResponse {
-    revision: u64,
-}
-impl FiveLevelPagingResponse {
-    impl_base_fns!();
 }
 
 /// A response to a [smp request](crate::request::SmpRequest). This response

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -24,8 +24,8 @@ impl GotoAddress {
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    /// The ACPI processor ID, according to the ACPI MADT.
     pub id: u32,
+    /// The ACPI processor ID, according to the ACPI MADT.
     #[cfg(target_arch = "riscv64")]
     pub id: u64,
 

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -20,49 +20,29 @@ impl GotoAddress {
 }
 
 /// A CPU entry in the SMP request.
-#[cfg(target_arch = "x86_64")]
 #[repr(C)]
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub id: u32,
+    /// The ACPI processor ID, according to the ACPI MADT.
+    #[cfg(target_arch = "riscv64")]
+    pub id: u64,
+
+    #[cfg(target_arch = "x86_64")]
     /// The APIC ID, according to the ACPI MADT.
     pub lapic_id: u32,
-    _reserved: core::mem::MaybeUninit<u64>,
-    /// The address to jump to. Writing to this field will cause the core to
-    /// jump to the given function. The function will receive a pointer to this
-    /// structure, and it will have its own 64KiB (or requested-size) stack.
-    pub goto_address: GotoAddress,
-    /// Free for use by the kernel.
-    pub extra: u64,
-}
 
-/// A CPU entry in the SMP request.
-#[cfg(target_arch = "aarch64")]
-#[repr(C)]
-pub struct Cpu {
-    /// The ACPI processor ID, according to the ACPI MADT.
-    pub id: u32,
-    /// The GIC interface number, according to the ACPI MADT.
-    pub gic_iface_no: u32,
+    #[cfg(target_arch = "aarch64")]
+    _reserved1: core::mem::MaybeUninit<u32>,
+    #[cfg(target_arch = "aarch64")]
     /// The MPIDR of the CPU, according to the ACPI MADT or the device tree.
     pub mpidr: u64,
-    _reserved: core::mem::MaybeUninit<u64>,
-    /// The address to jump to. Writing to this field will cause the core to
-    /// jump to the given function. The function will receive a pointer to this
-    /// structure, and it will have its own 64KiB (or requested-size) stack.
-    pub goto_address: GotoAddress,
-    /// Free for use by the kernel.
-    pub extra: u64,
-}
 
-/// A CPU entry in the SMP request.
-#[cfg(target_arch = "riscv64")]
-#[repr(C)]
-pub struct Cpu {
-    /// The ACPI processor ID, according to the ACPI MADT.
-    pub id: u64,
+    #[cfg(target_arch = "riscv64")]
     /// The hart ID, according to the ACPI MADT or the device tree.
     pub hartid: u64,
+
     _reserved: core::mem::MaybeUninit<u64>,
     /// The address to jump to. Writing to this field will cause the core to
     /// jump to the given function. The function will receive a pointer to this

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -24,23 +24,23 @@ impl GotoAddress {
 pub struct Cpu {
     /// The ACPI processor ID, according to the ACPI MADT.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    pub id: u32,
     /// The ACPI processor ID, according to the ACPI MADT.
+    pub id: u32,
     #[cfg(target_arch = "riscv64")]
     pub id: u64,
 
-    #[cfg(target_arch = "x86_64")]
     /// The APIC ID, according to the ACPI MADT.
+    #[cfg(target_arch = "x86_64")]
     pub lapic_id: u32,
 
     #[cfg(target_arch = "aarch64")]
     _reserved1: core::mem::MaybeUninit<u32>,
-    #[cfg(target_arch = "aarch64")]
     /// The MPIDR of the CPU, according to the ACPI MADT or the device tree.
+    #[cfg(target_arch = "aarch64")]
     pub mpidr: u64,
 
-    #[cfg(target_arch = "riscv64")]
     /// The hart ID, according to the ACPI MADT or the device tree.
+    #[cfg(target_arch = "riscv64")]
     pub hartid: u64,
 
     _reserved: core::mem::MaybeUninit<u64>,


### PR DESCRIPTION
This PR updates the library to use the most recent limine protocol revision. Specifically, it:
- Adds `FirmwareTypeRequest`
- Updates the base protocol revision
- Updates `PagingModeRequest`
- Removes `FiveLevelPagingRequest`, as it is no longer documented in the limine protocol
- Updates `smp::Cpu`